### PR TITLE
[draft] Add authentification to routes when possible

### DIFF
--- a/controllers/auth/handler.go
+++ b/controllers/auth/handler.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"fmt"
+	"github.com/dgrijalva/jwt-go"
+	"projet_wiki/models"
+	"net/http"
+	"os"
+)
+
+const (	
+	JWTUsername = "username"
+)
+
+type claimsStruct struct {
+	Username string `json:"username"`
+	jwt.StandardClaims
+}
+
+const JwtCookieName = "token"
+
+func GetRequestUser(r *http.Request) (*models.User, error) {
+	cookie, err := r.Cookie(JwtCookieName)
+	if err != nil {
+		return nil, fmt.Errorf("err : %v", err)
+		
+	}
+
+	claims := jwt.MapClaims{}
+	_, err = jwt.ParseWithClaims(cookie.Value, claims, func(token *jwt.Token) (interface{}, error) {
+		return []byte(os.Getenv("JWT_KEY")), nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("err : %v", err)
+	}
+
+	var RequestUser models.User
+
+	for key, val := range claims {
+		if key == JWTUsername {
+			RequestUser.Username = fmt.Sprintf("%v", val)
+		}
+	}
+
+	if RequestUser.Username == "" {
+		fmt.Println("halp")
+		return nil, fmt.Errorf("could not retrieve username, issue with cookie")
+	}
+
+	return &RequestUser, nil
+}

--- a/controllers/handleSignin.go
+++ b/controllers/handleSignin.go
@@ -42,5 +42,12 @@ func Signin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	http.SetCookie(w, &http.Cookie{
+		Name:    "token",
+		Value:   tokenString,
+		Expires: expirationTime,
+	})
+
+
 	w.Header().Set("Authorization", fmt.Sprintf("Bearer %s", tokenString))
 }

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"projet_wiki/database"
 	"projet_wiki/models"
-
+	"projet_wiki/controllers/auth"
 	"github.com/gorilla/mux"
 	"golang.org/x/crypto/bcrypt"
 )
@@ -65,6 +65,15 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		fmt.Println(err)
 	}
+	UserAuth, errAuth := auth.GetRequestUser(r)
+	if errAuth != nil {
+		fmt.Println("user not connected")
+		return
+	}
+	if UserAuth.Username != user.Username {
+		fmt.Println("Incorrect account rights ")
+	    return
+	}
 	db.Delete(&user)
 }
 
@@ -83,6 +92,16 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 		fmt.Println(err)
 	}
 
+	UserAuth, errAuth := auth.GetRequestUser(r)
+	if errAuth != nil {
+		fmt.Println("user not connected")
+		return
+	}
+	if UserAuth.Username != user.Username {
+		fmt.Println("Incorrect account rights ")
+	    return
+	}
+	
 	user.Username = username
 
 	err2 := db.Save(&user)


### PR DESCRIPTION
Add route authentification logic when possible. Articles and comments lack a user object for uknown reasons, therefore we cannot implement it for those routes until that bug is fixed.